### PR TITLE
Fix Random Hangs in Daycare mode

### DIFF
--- a/modules/modes/_util.py
+++ b/modules/modes/_util.py
@@ -101,10 +101,6 @@ def follow_path(waypoints: list[tuple[int, int]], run: bool = True) -> Generator
     if get_game_state() != GameState.OVERWORLD:
         return
 
-    # Make sure that the player avatar can actually be controlled/moved right now.
-    if "heldMovementActive" not in get_map_objects()[0].flags:
-        return
-
     for waypoint in waypoints:
         yield from walk_to(waypoint, run)
 


### PR DESCRIPTION
A Fix for the random hangs in the Daycare mode

other modes that use `follow_path(...)` should be tested if they broke in some unforeseen ways